### PR TITLE
Fixed two-finger tap not working

### DIFF
--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -263,19 +263,25 @@ int touchCallback(int device, Finger* data, int nFingers, double timestamp,
     }
     
     if (nFingers == fingersQua) {
-      Finger* f1 = &data[0];
-      Finger* f2 = &data[1];
-      Finger* f3 = &data[2];
-      
       if (maybeMiddleClick == YES) {
-        middleclickX = (f1->normalized.pos.x + f2->normalized.pos.x + f3->normalized.pos.x);
-        middleclickY = (f1->normalized.pos.y + f2->normalized.pos.y + f3->normalized.pos.y);
+        for (int i = 0; i < fingersQua; i++)
+        {
+          mtPoint pos = ((Finger *)&data[i])->normalized.pos;
+          middleclickX += pos.x;
+          middleclickY += pos.y;
+        }
         middleclickX2 = middleclickX;
         middleclickY2 = middleclickY;
         maybeMiddleClick = NO;
       } else {
-        middleclickX2 = (f1->normalized.pos.x + f2->normalized.pos.x + f3->normalized.pos.x);
-        middleclickY2 = (f1->normalized.pos.y + f2->normalized.pos.y + f3->normalized.pos.y);
+        middleclickX2 = 0.0f;
+        middleclickY2 = 0.0f;
+        for (int i = 0; i < fingersQua; i++)
+        {
+          mtPoint pos = ((Finger *)&data[i])->normalized.pos;
+          middleclickX2 += pos.x;
+          middleclickY2 += pos.y;
+        }
       }
     }
   }


### PR DESCRIPTION
Hello.

I found that the middle-click with the two-finger tap doesn't work when I changed a setting with the command below.
`$ defaults write com.rouge41.middleClick fingers 2`

In my investigation, `f3->normalized.pos.x` and `f3->normalized.pos.y` were "nan" when two-finger tap was triggered.
Consequently, middleclickX, middleclickY, middleclickX2, and middleclickY2 were "nan", so the condition `delta < 0.4f` at l.228 didn't work well.

I think the number of `((Finger *)&data[i])->normalized.pos` should be aligned with fingersQua.