### PR TITLE
Fix device added callback

### DIFF
--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -102,14 +102,12 @@ BOOL wasThreeDown;
           @"attached devices",
           err);
     IONotificationPortDestroy(port);
+  } else {
+    io_object_t item;
+    while ((item = IOIteratorNext(handle))) {
+      IOObjectRelease(item);
+    }
   }
-//  else {
-    /// Iterate through all the existing entries to arm the notification. Removed due to: https://stackoverflow.com/questions/1209130/iphone-sdk-exc-bad-access-with-cfrelease-for-abaddressbookref
-//    io_object_t item;
-//    while ((item = IOIteratorNext(handle))) {
-//      CFRelease(item);
-//    }
-//  }
   
   // when displays are reconfigured restart of the app is needed, so add a calback to the
   // reconifguration of Core Graphics
@@ -309,11 +307,10 @@ static void restartApp()
 void multitouchDeviceAddedCallback(void* _controller,
                                    io_iterator_t iterator)
 {
-  /// Loop through all the returned items. Removed due to: https://stackoverflow.com/questions/1209130/iphone-sdk-exc-bad-access-with-cfrelease-for-abaddressbookref
-//  io_object_t item;
-//  while ((item = IOIteratorNext(iterator))) {
-//    CFRelease(item);
-//  }
+  io_object_t item;
+  while ((item = IOIteratorNext(iterator))) {
+    IOObjectRelease(item);
+  }
   
   NSLog(@"Multitouch device added, restarting...");
   Controller* controller = (Controller*)_controller;


### PR DESCRIPTION
Ref: https://github.com/artginzburg/MiddleClick-BigSur/issues/28#issuecomment-1337576496

Switches `CFRelease` to `IOObjectRelease` to fix callback when new devices added, which was broken in [`5aca15`](https://github.com/artginzburg/MiddleClick-BigSur/commit/5aca15e0dfdbc7b07e0c72b4df384c682d39f0ea#diff-2185ed73ff59962c5e075a474403402cac1282cc4fc3060f5c94801774282d5dL105-R310)

Reproduction:

1. Connect Magic Mouse
2. Start MiddleClick.app -> ✅ Middle click functionality works
3. Turn Magic Mouse off and then turn it on again
4.  💥 Middle click functionality broken

Before:

<img width="604" alt="Screenshot 2022-12-05 at 16 30 24" src="https://user-images.githubusercontent.com/1935696/205676525-bcd63e14-b69a-47b3-a7ad-90663203a5ee.png">


After:

![Screenshot 2022-12-05 at 16 27 03](https://user-images.githubusercontent.com/1935696/205676419-aa724f1a-834d-4b0d-a4cb-b79cf180f8cd.png)
