### PR TITLE
Better UX of the click mode setting

### DIFF
--- a/MiddleClick/Controller.h
+++ b/MiddleClick/Controller.h
@@ -6,5 +6,6 @@
 - (void)start;
 - (void)setMode:(BOOL)click;
 - (BOOL)getClickMode;
+- (void)resetClickMode;
 
 @end

--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -68,8 +68,8 @@ CFRunLoopSourceRef currentRunLoopSource;
   
   fingersQua = [[NSUserDefaults standardUserDefaults] integerForKey:@"fingers"];
   
-  needToClick =
-  [[NSUserDefaults standardUserDefaults] boolForKey:@"needClick"];
+  NSString* needToClickNullable = [[NSUserDefaults standardUserDefaults] valueForKey:@"needClick"];
+  needToClick = needToClickNullable ? [[NSUserDefaults standardUserDefaults] boolForKey:@"needClick"] : [self getIsSystemTapToClickDisabled];
   
   NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
   [NSApplication sharedApplication];
@@ -389,6 +389,25 @@ static void unregisterMTDeviceCallback(MTDeviceRef device, MTContactCallbackFunc
     MTUnregisterContactFrameCallback(device, callback); // unassign callback for device
     MTDeviceStop(device); // stop sending events
     MTDeviceRelease(device);
+}
+
+- (BOOL)getIsSystemTapToClickDisabled {
+  NSString* isSystemTapToClickEnabled = [self runCommand:(@"defaults read com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking")];
+  return [isSystemTapToClickEnabled isEqualToString:@"0\n"];
+}
+
+- (NSString *)runCommand:(NSString *)commandToRun {
+  NSPipe* pipe = [NSPipe pipe];
+  
+  NSTask* task = [[NSTask alloc] init];
+  [task setLaunchPath: @"/bin/sh"];
+  [task setArguments:@[@"-c", [NSString stringWithFormat:@"%@", commandToRun]]];
+  [task setStandardOutput:pipe];
+  
+  NSFileHandle* file = [pipe fileHandleForReading];
+  [task launch];
+  
+  return [[NSString alloc] initWithData:[file readDataToEndOfFile] encoding:NSUTF8StringEncoding];
 }
 
 @end

--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -230,6 +230,11 @@ static void unregisterMouseCallback()
   [[NSUserDefaults standardUserDefaults] setBool:click forKey:@"needClick"];
   needToClick = click;
 }
+- (void)resetClickMode
+{
+  [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"needClick"];
+  needToClick = [self getIsSystemTapToClickDisabled];
+}
 
 // listening to mouse clicks to replace them with middle clicks if there are 3
 // fingers down at the time of clicking this is done by replacing the left click

--- a/MiddleClick/TrayMenu.h
+++ b/MiddleClick/TrayMenu.h
@@ -7,11 +7,11 @@
   Controller* myController;
   NSMenuItem* accessibilityPermissionStatusItem;
   NSMenuItem* accessibilityPermissionActionItem;
-  NSMenuItem* tapItem;
-  NSMenuItem* clickItem;
+  NSMenuItem* infoItem;
+  NSMenuItem* tapToClickItem;
 }
 - (id)initWithController:(Controller*)ctrl;
 - (void)setChecks;
-- (void)setClick:(id)sender;
-- (void)setTap:(id)sender;
+- (void)toggleTapToClick:(id)sender;
+- (void)resetTapToClick:(id)sender;
 @end

--- a/MiddleClick/TrayMenu.m
+++ b/MiddleClick/TrayMenu.m
@@ -57,27 +57,27 @@
   }
 }
 
-- (void)setClick:(id)sender
+- (void)toggleTapToClick:(id)sender
 {
-  [myController setMode:YES];
+  [myController setMode:[sender state] == NSControlStateValueOn];
   [self setChecks];
 }
 
-- (void)setTap:(id)sender
+- (void)resetTapToClick:(id)sender
 {
-  [myController setMode:NO];
+  [myController resetClickMode];
   [self setChecks];
 }
 
 - (void)setChecks
 {
-  if ([myController getClickMode]) {
-    [clickItem setState:NSControlStateValueOn];
-    [tapItem setState:NSControlStateValueOff];
-  } else {
-    [clickItem setState:NSControlStateValueOff];
-    [tapItem setState:NSControlStateValueOn];
-  }
+  bool clickMode = [myController getClickMode];
+  NSString* clickModeInfo = clickMode ? @"Click" : @"Click or Tap";
+  
+  int fingersQua = (int)[[NSUserDefaults standardUserDefaults] integerForKey:@"fingers"];
+  
+  [infoItem setTitle:[clickModeInfo stringByAppendingFormat: @" with %d Fingers", fingersQua]];
+  [tapToClickItem setState:clickMode ? NSControlStateValueOff : NSControlStateValueOn];
 }
 
 - (void)actionQuit:(id)sender
@@ -92,8 +92,6 @@
   
   
   
-  int fingersQua = (int)[[NSUserDefaults standardUserDefaults] integerForKey:@"fingers"];
-  
   [self createMenuAccessibilityPermissionItems:menu];
   
   // Add About
@@ -104,15 +102,22 @@
   
   [menu addItem:[NSMenuItem separatorItem]];
   
-  clickItem = [menu addItemWithTitle:[NSString stringWithFormat: @"%d Finger Click", fingersQua]
-                              action:@selector(setClick:)
-                       keyEquivalent:@""];
-  [clickItem setTarget:self];
+  infoItem = [menu addItemWithTitle:@""
+                             action:nil
+                      keyEquivalent:@""];
+  [infoItem setTarget:self];
   
-  tapItem = [menu addItemWithTitle:[NSString stringWithFormat: @"%d Finger Tap", fingersQua]
-                            action:@selector(setTap:)
-                     keyEquivalent:@""];
-  [tapItem setTarget:self];
+  tapToClickItem = [menu addItemWithTitle:@"Tap to click"
+                                   action:@selector(toggleTapToClick:)
+                            keyEquivalent:@""];
+  [tapToClickItem setTarget:self];
+  
+  NSMenuItem* resetItem = [menu addItemWithTitle:@"Reset to System Settings"
+                                          action:@selector(resetTapToClick:)
+                                   keyEquivalent:@""];
+  resetItem.alternate = YES;
+  resetItem.keyEquivalentModifierMask = NSEventModifierFlagOption;
+  [resetItem setTarget:self];
   
   [self setChecks];
   


### PR DESCRIPTION
This basically matches MiddleClick's interface with `System Settings` > `Trackpad` > `Point & Click`.

- The click mode reads its state from System Settings, unless the user manually changes it.
- Instead of 2 menu items — each for each click mode, there is now one — "Tap to click", which is checked/unchecked accordingly.
- There's also an info menu item that shows current user settings.
- The click mode can be reset to match System Settings by clicking the "Tap to click" menu item while holding the <kbd>Option</kbd> key.