### PR TITLE
fix: Restore Fast User Switching handling on macOS 15+

### DIFF
--- a/MiddleClick/Controller.swift
+++ b/MiddleClick/Controller.swift
@@ -13,20 +13,12 @@ import AppKit
 
   private static let immediateRestart = false
 
-  /// Feature flag to enable/disable session handling for Fast User Switching.
-  private static let enableSessionHandling = decideOnEnableSessionHandling()
-
   func start() {
     log.info("Starting listeners...")
 
     TouchHandler.shared.registerTouchCallback()
     observeWakeNotification()
-    if Self.enableSessionHandling {
-      log.info("Session handling enabled - will monitor Fast User Switching")
-      setupSessionHandling()
-    } else {
-      log.info("Session handling disabled - macOS 15 handles session switching correctly")
-    }
+    setupSessionHandling()
     multitouchManager.setupMultitouchListener()
     setupDisplayReconfigurationCallback()
 
@@ -44,7 +36,7 @@ import AppKit
 
   /// Schedule listeners to be restarted. If a restart is pending, discard its delay and use the most recently requested delay.
   func scheduleRestart(_ delay: TimeInterval, reason: String) {
-    if Self.enableSessionHandling && !isUserSessionActive {
+    if !isUserSessionActive {
       restartLog.info("\(reason), but user session is inactive - skipping restart")
       return
     }
@@ -62,7 +54,7 @@ import AppKit
   func restartListeners() {
     log.info("Restarting now...")
     stopUnstableListeners()
-    if !Self.enableSessionHandling || isUserSessionActive {
+    if isUserSessionActive {
       startUnstableListeners()
       log.info("Restart success.")
     } else {
@@ -123,28 +115,21 @@ fileprivate extension CGDisplayChangeSummaryFlags {
 }
 
 // MARK: - Session Handling for Fast User Switching
+//
+// Always enabled: the multitouch session switching bug (#127) still reproduces
+// on macOS 26.5 when MiddleClick runs in more than one logged-in user's session —
+// concurrent multitouch device registrations from different sessions break frame
+// delivery. Stopping listeners while the session is off-console is safe on every
+// macOS version, so no version gate.
 
 fileprivate extension Controller {
   /// Session state tracking variables (using static storage for simplicity)
   private static var _userSessionActive = true
-  private static var _lastSessionChangeTime: Date = .distantPast
 
   /// Public accessor for session state (used by scheduleRestart and restartListeners)
   var isUserSessionActive: Bool { Self._userSessionActive }
 
-  /// Enable for macOS versions that have the multitouch session switching bug.
-  /// Disable for macOS 15.0+ (Sequoia) where Apple fixed the issue.
-  ///
-  /// This is actually not confirmed, but I can't reproduce issue #127 on macOS 15.7.
-  private static func decideOnEnableSessionHandling() -> Bool {
-    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-    if osVersion.majorVersion < 15 {
-      return true
-    }
-    return false
-  }
-
-  /// Initialize session handling - call this from start() when feature is enabled
+  /// Initialize session handling - call this from start()
   func setupSessionHandling() {
     Self._userSessionActive = true
     observeSessionNotifications()
@@ -166,13 +151,6 @@ fileprivate extension Controller {
   }
 
   @objc private func receiveSessionResignActiveNote(_ note: Notification) {
-    let now = Date()
-    guard now.timeIntervalSince(Self._lastSessionChangeTime) > 0.5 else {
-      log.info("Ignoring session resign - too soon after last change")
-      return
-    }
-    Self._lastSessionChangeTime = now
-
     log.info("User session resigned active, stopping listeners")
     Self._userSessionActive = false
     restartTimer?.invalidate()
@@ -184,18 +162,11 @@ fileprivate extension Controller {
   }
 
   @objc private func receiveSessionBecomeActiveNote(_ note: Notification) {
-    let now = Date()
-    guard now.timeIntervalSince(Self._lastSessionChangeTime) > 0.5 else {
-      log.info("Ignoring session become active - too soon after last change")
-      return
-    }
-    Self._lastSessionChangeTime = now
-
-    log.info("User session became active, starting listeners")
+    log.info("User session became active, restarting listeners")
     Self._userSessionActive = true
 
     DispatchQueue.main.async {
-      self.startUnstableListeners()
+      self.restartListeners()
     }
   }
 }


### PR DESCRIPTION
Closes #127.

Hi! This brings back the Fast User Switching fix from #127 for macOS 15 and newer, where it's currently disabled.

**Problem**

When two users are logged in and both run MiddleClick, the middle-click gesture stops working for whichever user isn't the first one logged in. You have to log the other user out for it to start working again. I run into this every day on macOS 26.5.2 with two accounts and Fast User Switching.

#127 was already fixed once (in 5f4af9e), but that fix is gated behind a macOS version check that turns it off on 15+, on the assumption that Apple fixed the underlying issue in Sequoia. That doesn't seem to be the case, it still reproduces on 26.5.2.

**Root cause**

Both users' MiddleClick instances register and start callbacks on the same `AppleMultitouchDevice`. With two sessions holding the device at once, the private MultitouchSupport framework stops delivering frame callbacks reliably. Stopping the listeners in whichever session isn't on-console removes the contention, which is exactly what the existing session handling already does, it just wasn't running on 15+.

**Changes**

- Remove the version gate so session handling runs on every macOS version. Stopping listeners while a session is in the background is harmless everywhere, so there's no downside to leaving it on.
- Drop the 0.5s debounce that was shared between the resign and become-active handlers. Because it was shared, a become-active arriving within 0.5s of a resign could get dropped and leave the active session with its listeners off.
- Route the become-active handler through `restartListeners()` (stop-then-start) instead of a bare start, so repeated or bursty session notifications are idempotent.

**Testing**

Tested on a trackpad, macOS 26.5.2, with two user accounts:

- Switched back and forth between both users repeatedly, including quick switches. The gesture now works in whichever session is active, where before only the first user's session worked.
- Confirmed from the logs that the inactive session releases the device and the active one reclaims it:

```
User session resigned active, stopping listeners
Successfully unregistered mouse callback.
...
Display reconfigured, but user session is inactive - skipping restart
User session became active, restarting listeners
Restarting now...
Successfully registered mouse callback.
Restart success.
```

I couldn't test on macOS < 15 (no machine on it). That path already had session handling enabled before this PR, so it's unchanged there apart from the debounce simplification above. Happy to attach a test build or tweak anything if a reviewer on an older version wants to verify.
